### PR TITLE
fix: changed GITHUB TOKEN to PAT => allows use of ruleset

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Authors
 
-- Farhan Bin Faisal trying release_token
+- Farhan Bin Faisal
 - Michael Suriawan  
 - Lukman Lateef
 


### PR DESCRIPTION
- [x] Changed GITHUB_TOKEN to RELEASE_TOKEN with PAT (36.8.4 of course book)
- Allows Bot to have admin privilege and push to main
- Allows us to keep the ruleset active